### PR TITLE
Feature/t5114/add black code formatter

### DIFF
--- a/code/requirements.txt
+++ b/code/requirements.txt
@@ -3,3 +3,4 @@ scikit-learn==0.24.2
 transformers==4.10.0
 omegaconf==2.3.0
 wandb==0.15.1 --use-feature=2020-resolver
+black==23.3.0


### PR DESCRIPTION
# feature/t5114/add-black-code-formatter

## 변경 사항

- requirements.txt에 "black==23.3.0"를 추가하였습니다.

## 문제 해결 방법

- 팀 코딩컨벤션 규칙에 따라 팀원 모두가 공통적으로 사용해야 하는 패키지이지만 black이 적용이 되지 않은 채 코드를 작성하게 되는 것을 방지하고자 requirements.txt에 추가 하였습니다.
- 아직 black 설치가 되어있지 않은 분들은 팀 노션 KLUE-RE(문장 내 개체간 관계 추출) -> 자유게시판 -> 코딩컨벤션에 docstring 관련한 내용을 정리한 것을 참고하여 vscode 설정 및 사용법을 확인해 주시면 감사드리겠습니다.

![image](https://github.com/boostcampaitech5/level2_klue-nlp-01/assets/93263215/0da9c24b-55c8-491c-8004-344b6bd9d096)


## 테스트

- black 패키지 내용을 추가하였을 때 에러가 발생하지 않는 것을 확인하였습니다.
